### PR TITLE
Update block.cljs

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1286,7 +1286,7 @@
          ["Email" address]
          (let [{:keys [local_part domain]} address
                address (str local_part "@" domain)]
-           [:a {:href (str "mainto:" address)} address])
+           [:a {:href (str "mailto:" address)} address])
 
          ["Nested_link" link]
          (nested-link config html-export? link)


### PR DESCRIPTION
fix typo for email hrefs. was: maiNto, should: maiLto.

See [issue 5080](https://github.com/logseq/logseq/issues/5080)